### PR TITLE
lib: check for error http.Get

### DIFF
--- a/lib.go
+++ b/lib.go
@@ -24,7 +24,10 @@ func Request(str string) int {
 	client := http.Client{
 		Timeout: time.Millisecond * 200,
 	}
-	resp, _ := client.Get(str)
+	resp, err := client.Get(str)
+	if err != nil {
+		return -1
+	}
 	return resp.StatusCode
 }
 


### PR DESCRIPTION
this commit introduces error handling for the http.Get call in lib.Request, therefore mitigating the possiblity of null pointer dereferences when accessing the (*Response).StatusCode field.

See https://pkg.go.dev/net/http#Get and https://pkg.go.dev/net/http#Response

Thanks to @raphael10-collab for reporting this bug, see: https://github.com/respondchat/c-go-interop/issues/1